### PR TITLE
Changed `footer` colors to increase contrast ratio

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -360,8 +360,8 @@ nav input[type=checkbox]:checked ~ ul { display: block; }
 /* Footer
 –––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––– */
 footer {
-  background: #565A5E;
-  color: #BBB;
+  background: #565A50;
+  color: #FFF;
   font-size: 0.9em;
   margin: 0 -2.2em -3em;
   padding: 1.5em 2em 1em 2em;


### PR DESCRIPTION
After a check with Lighthouse, the report stated that the colours used in the footer of the page did not comply with the minimum contrast ratio required for WCAG AA

The minimum required colour ratio is 4.5:1, but the footer colours ratio is approximately 3.6:1 at follows.
![image](https://user-images.githubusercontent.com/28826167/142720999-63414b74-29a3-40fd-b716-c1ff59471f0d.png)
![image](https://user-images.githubusercontent.com/28826167/142721162-d25380e5-2b13-4e69-9457-f520266b6390.png)

After a few attempts I managed to bring the ratio up to 7:1 (which is the value required for the WCAG AAA mark).
![image](https://user-images.githubusercontent.com/28826167/142721194-f25312ee-a84e-4b88-a25c-1cfee3895b6f.png)
![image](https://user-images.githubusercontent.com/28826167/142721217-8f7de1f6-d457-4b8e-97b3-a0e98a1ce01a.png)

Please consider changing the colours of the footer, so that all the categories of visually impaired users can be included. 
Best Regards
Luca Polese