### PR TITLE
get/online/cocalc: point to better landing page

### DIFF
--- a/get.md
+++ b/get.md
@@ -100,7 +100,7 @@ automatically receive updates from CTAN.
       like
       <a href="https://www.overleaf.com/">Overleaf</a>,
       <a href="https://papeeria.com">Papeeria</a>,
-    or <a href="https://cocalc.com">CoCalc</a>
+    or <a href="https://cocalc.com/features/latex-editor">CoCalc</a>
     offer the
     ability to edit, view and download LaTeX files and resulting
     PDFs.</p>


### PR DESCRIPTION
The main landing page of CoCalc is not so good for LaTeX. This changes the URL to point to the landing page talking about the LaTeX editor, that's all.