### PR TITLE
Ensure 0 padding for navigation list

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -322,7 +322,7 @@ header span { position: absolute !important; top: -9999em !important; left: -999
 /* Navigation
 –––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––– */
 nav { position: relative; }
-nav ul { background: #008080; list-style: none; margin: 0; text-align: center; width: 100%; }
+nav ul { background: #008080; list-style: none; margin: 0; padding: 0; text-align: center; width: 100%; }
 nav ul li { display: inline-block; margin: -1px 0 0 0; }
 nav ul li a, 
 nav ul li a:visited,


### PR DESCRIPTION
To overwrite the `padding-left: 1em;` set for all lists.
https://github.com/latex3/latex3.github.io/blob/bbbe54e0fd72aba96a4c5de36396d7274c48c15b/css/screen.css#L207-L209

Before, the navigation is wider than the main body:
![image](https://github.com/user-attachments/assets/536806a5-ddf4-4fb0-943a-0abd0c172f1a)

After
![image](https://github.com/user-attachments/assets/f8de940a-0322-4d29-9540-6d3d8422b35b)
